### PR TITLE
Fix the cb is not a function in new key generation on the new i18next

### DIFF
--- a/index.js
+++ b/index.js
@@ -211,7 +211,7 @@ class Backend {
         ),
       );
 
-      if (cb) cb();
+      if (cb && typeof cb === 'function') cb();
     } catch (error) {
       this.opts.createOnError(error);
       if (cb) cb(error);


### PR DESCRIPTION
in the new versions when a key add to the database , we get a cb is not a function